### PR TITLE
Collapsing tile fix

### DIFF
--- a/objects/obj_collapsing_tile/Step_0.gml
+++ b/objects/obj_collapsing_tile/Step_0.gml
@@ -1,6 +1,6 @@
-/// @description Collaps it
+/// @description Collapse it
 
-	if(obj_player.ground && player_collide_object(noone, COLLISION.BOTTOM) && !triggered)
+	if(obj_player.ground && player_collide_object(noone, COLLISION.BOTTOM) && !triggered && obj_player.y < bbox_top)
 	{
 		triggered = true
 		event_user(1) //generates tile data to be saved


### PR DESCRIPTION
previously if you were standing on the ground inside of a semi-solid collapsing tile, it would break. Now it only breaks if the player is grounded AND above it